### PR TITLE
Update walkthrough.sh

### DIFF
--- a/doc/walkthrough.sh
+++ b/doc/walkthrough.sh
@@ -21,6 +21,7 @@ go install github.com/social4git/social4git/social4git@latest
 
 # (3) Create a config file for your social identity
 
+mkdir -p $HOME/.social4git
 cat <<EOF >> ~/.social4git/config.json
 {
      "handle": "https://github.com/petar/petar.social4git.public.git",


### PR DESCRIPTION
Add mkdir to create userspace .social4git directory.  On macos, bash will fail with:
```bash
-bash: /Users/username/.social4git/config.json: No such file or directory 
```
if directory doesn't exist first.